### PR TITLE
Digest size is 256 bit, i.e. 8 uint32_t

### DIFF
--- a/random-generator/rng.h
+++ b/random-generator/rng.h
@@ -8,7 +8,7 @@
 typedef struct {
 	uint32_t ctr;
 	uint32_t state[16];
-	uint32_t digest[32];
+	uint32_t digest[8];
 } rng_ctx;
 
 void rng_init(rng_ctx *ctx);


### PR DESCRIPTION
Change from 32 uint32_t (1024 bits) bytes to 8 uint32_t (256 bits, or 32 bytes), which is what BLAKE2s generates as digest.