### PR TITLE
Building from tagged tkey-libs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: tillitis/tkey-libs
-          ref: main
+          ref: v0.0.2
           path: tkey-libs
 
       - name: fix

--- a/README.md
+++ b/README.md
@@ -127,19 +127,38 @@ again before doing any operation.
 You have two options for build tools: either use our OCI image
 `ghcr.io/tillitis/tkey-builder` or native tools.
 
-In either case, you need the device libraries in a directory next to
-this one. The device libraries are available in:
-
-https://github.com/tillitis/tkey-libs
-
-Clone and build the device libraries first. You will most likely want
-to specify a release with something like `-b v0.0.1`:
+With native tools you should be able to use our build script:
 
 ```
-$ git clone -b v0.0.1 --depth 1 https://github.com/tillitis/tkey-libs
+$ ./build.sh
+```
+
+which also clones and builds the TKey device
+libraries: https://github.com/tillitis/tkey-libs
+
+If you want to do it manually please inspect the build script, but
+basically you clone `tkey-libs` next to this folder, build it, and
+then build this application using `make`
+
+Something like this:
+
+```
+$ git clone -b v0.0.2 --depth 1 https://github.com/tillitis/tkey-libs
 $ cd tkey-libs
 $ make
 ```
+
+navigate back to this folder and run:
+
+```
+make
+```
+
+If you cloned `tkey-libs` to somewhere else then the default, set
+`LIBDIR` to the path of the directory.
+
+Please see [Tools & libraries](https://dev.tillitis.se/tools/) in the Development Handbook
+for detailed information on the currently supported build and development environment.
 
 ### Building with Podman
 
@@ -159,29 +178,6 @@ apt install podman rootlesskit slirp4netns
 ```
 
 should be enough to get you a working Podman setup.
-
-### Building with native tools
-
-To build with native tools you need at least the `clang`, `llvm`,
-`lld`, packages installed. Version 15 or later of LLVM/Clang is for
-support of our architecture (RV32\_Zmmul). Ubuntu 22.10 (Kinetic) is
-known to have this. Please see
-[toolchain_setup.md](https://github.com/tillitis/tillitis-key1/blob/main/doc/toolchain_setup.md)
-(in the tillitis-key1 repository) for detailed information on the
-currently supported build and development environment.
-
-Build everything:
-
-```
-$ make
-```
-
-If you cloned `tkey-libs` to somewhere else then the default, set
-`LIBDIR` to the path of the directory.
-
-If your available `objcopy` is anything other than the default
-`llvm-objcopy`, then define `OBJCOPY` to whatever they're called on
-your system.
 
 ## Licenses and SPDX tags
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+git clone https://github.com/tillitis/tkey-libs.git ../tkey-libs
+
+tkey_libs_version="v0.0.2"
+
+printf "Building tkey-libs with version: %s\n" "$tkey_libs_version"
+
+make -j -C ../tkey-libs clean
+cd ../tkey-libs && git checkout "$tkey_libs_version" && cd ../tkey-random-generator
+make -j -C ../tkey-libs
+
+make -j

--- a/make-release-build-macos.sh
+++ b/make-release-build-macos.sh
@@ -6,13 +6,19 @@ version comes from a clean version tag.
 
 Specify version of the release to build, and what tkey-libs tag to use when invoking this script.
 
-Use as "./make-release-build-macos.sh <verison_name_of_release> <tkey_libs_tag>
+Use as "./make-release-build-macos.sh <version_name_of_release> <tkey_libs_tag>
 
 Use to build macos targets.
 
 Requires tkey-libs to be cloned next to this top folder.
 
 EOF
+
+if [ "$#" -ne 2 ]
+then
+  echo "Please supply both release_version and tkey_libs_tag"
+  exit 1
+fi
 
 version="$1"
 if [ -z "$version" ]; then

--- a/make-release-build-macos.sh
+++ b/make-release-build-macos.sh
@@ -4,6 +4,10 @@ cat <<EOF
 Note that it is your responsibility that the code that is built as a specific
 version comes from a clean version tag.
 
+Specify version of the release to build, and what tkey-libs tag to use when invoking this script.
+
+Use as "./make-release-build-macos.sh <verison_name_of_release> <tkey_libs_tag>
+
 Use to build macos targets.
 
 Requires tkey-libs to be cloned next to this top folder.
@@ -23,6 +27,9 @@ if ! hash 2>/dev/null sha512sum; then
   }
 fi
 
+tkey_libs_version="$1"
+shift
+
 # look for tkey-libs
 if [ ! -e ../tkey-libs ]; then
   printf "Could not find tkey-libs.\n"
@@ -31,6 +38,7 @@ fi
 
 # build a fresh tkey-libs
 make -C ../tkey-libs clean
+cd ../tkey-libs && git checkout "$tkey_libs_version" && cd ../tkey-random-generator
 make -C ../tkey-libs podman
 
 # build application binary using podman

--- a/make-release-build.sh
+++ b/make-release-build.sh
@@ -6,7 +6,7 @@ version comes from a clean version tag.
 
 Specify version of the release to build, and what tkey-libs tag to use when invoking this script.
 
-Use as "./make-release-build-macos.sh <verison_name_of_release> <tkey_libs_tag>
+Use as "./make-release-build.sh <version_name_of_release> <tkey_libs_tag>
 
 
 This script only builds for linux and windows. The macos version requires CGO
@@ -15,6 +15,12 @@ to compile, hence it cannot be cross-compiled, i.e. use podman.
 Requires tkey-libs to be cloned next to this top folder.
 
 EOF
+
+if [ "$#" -ne 2 ]
+then
+  echo "Please supply both release_version and tkey_libs_tag"
+  exit 1
+fi
 
 version="$1"
 if [ -z "$version" ]; then

--- a/make-release-build.sh
+++ b/make-release-build.sh
@@ -4,6 +4,11 @@ cat <<EOF
 Note that it is your responsibility that the code that is built as a specific
 version comes from a clean version tag.
 
+Specify version of the release to build, and what tkey-libs tag to use when invoking this script.
+
+Use as "./make-release-build-macos.sh <verison_name_of_release> <tkey_libs_tag>
+
+
 This script only builds for linux and windows. The macos version requires CGO
 to compile, hence it cannot be cross-compiled, i.e. use podman.
 
@@ -24,6 +29,8 @@ if ! hash 2>/dev/null sha512sum; then
   }
 fi
 
+tkey_libs_version="$1"
+shift
 # look for tkey-libs
 if [ ! -e ../tkey-libs ]; then
   printf "Could not find tkey-libs.\n"
@@ -32,6 +39,7 @@ fi
 
 # build a fresh tkey-libs
 make -C ../tkey-libs clean
+cd ../tkey-libs && git checkout "$tkey_libs_version" && cd ../tkey-random-generator
 make -C ../tkey-libs podman
 
 # build application binary using podman

--- a/tools/spdx-ensure
+++ b/tools/spdx-ensure
@@ -32,6 +32,7 @@ gotools/go.sum
 make-release-build-macos.sh
 make-release-build.sh
 random-generator/app.bin.sha512
+build.sh
 )
 
 is_missingok() {


### PR DESCRIPTION
Updated release scripts to take a version tag to build tkey-libs from.

Also added `build.sh`script to simplify build.