### PR TITLE
Add print to indicate progress

### DIFF
--- a/doc/tkey-random-generator.1
+++ b/doc/tkey-random-generator.1
@@ -86,6 +86,13 @@ Read FILE and hash its contents as the USS.\& Use '\&-'\& (dash) to read
 from stdin.\& The full contents are hashed unmodified (e.\&g.\& newlines are not stripped).\&
 .P
 .RE
+\fB--verbose\fR
+.P
+.RS 4
+Be more verbose, including reporting progress when writing to
+a file.\&
+.P
+.RE
 .SS verify
 .P
 \fBtkey-random-generator\fR verify FILE SIG-FILE PUBKEY-FILE [-b] [common

--- a/doc/tkey-random-generator.scd
+++ b/doc/tkey-random-generator.scd
@@ -65,6 +65,11 @@ Output can be chosen between stdout (in hexadecimal) or a binary file.
 	Read FILE and hash its contents as the USS. Use '-' (dash) to read
 	from stdin. The full contents are hashed unmodified (e.g. newlines are not stripped).
 
+*--verbose*
+
+	Be more verbose, including reporting progress when writing to
+	a file.
+
 ## verify
 
 *tkey-random-generator* verify FILE SIG-FILE PUBKEY-FILE [-b] [common

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/creack/goselect v0.1.2 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gen2brain/beeep v0.0.0-20230307103607-6e717729cb4f // indirect
 	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gen2brain/beeep v0.0.0-20230307103607-6e717729cb4f h1:oRm7Hy2dQWfHgOuOWRaYZf+kZcWJst7fxAlq+yjdLss=
 github.com/gen2brain/beeep v0.0.0-20230307103607-6e717729cb4f/go.mod h1:0W7dI87PvXJ1Sjs0QPvWXKcQmNERY77e8l7GFhZB/s4=
 github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 h1:qZNfIGkIANxGv/OqtnntR4DfOY2+BgwR60cAcu/i3SE=


### PR DESCRIPTION
Adding print outputs when generating data to a file.

The output is printed in human readable format, e.g. kB, MB etc.
The progress is printed with a dynamic step size. It is aiming for 10% increments, with a minimum of 256 bytes and a maximum of 50 kB (about 15 seconds to generate by TKey)

Generates something like this:
```
$ ./tkey-random-generator generate 5000000 -s -f test
Auto-detected serial port /dev/cu.usbmodem1101
Connecting to device on serial port /dev/cu.usbmodem1101...
Writing 5.0 MB bytes of random data to: test
1.0% 	 [50 kB / 5.0 MB]
2.0% 	 [100 kB / 5.0 MB]
3.0% 	 [150 kB / 5.0 MB]
4.0% 	 [200 kB / 5.0 MB]
5.0% 	 [250 kB / 5.0 MB]
6.0% 	 [300 kB / 5.0 MB]
7.0% 	 [350 kB / 5.0 MB]
8.0% 	 [400 kB / 5.0 MB]
9.0% 	 [450 kB / 5.0 MB]
10.0% 	 [500 kB / 5.0 MB]
11.0% 	 [550 kB / 5.0 MB]
12.0% 	 [600 kB / 5.0 MB]
13.0% 	 [650 kB / 5.0 MB]
14.0% 	 [700 kB / 5.0 MB]
15.0% 	 [750 kB / 5.0 MB]
16.0% 	 [800 kB / 5.0 MB]
17.0% 	 [850 kB / 5.0 MB]
18.0% 	 [900 kB / 5.0 MB]
19.0% 	 [950 kB / 5.0 MB]
20.0% 	 [1.0 MB / 5.0 MB]
...
```