### PR TITLE
Omit release-builds directory from *.sha512 files

### DIFF
--- a/make-release-build-macos.sh
+++ b/make-release-build-macos.sh
@@ -47,10 +47,10 @@ for arch in "amd64" "arm64"
 do
     printf "Building $version for $os $arch\n"
     make GOOS=$os GOARCH=$arch BUILD_CGO_ENABLED=1 TKEY_RANDOM_GENERATOR_VERSION="$version" tkey-random-generator
-    target="$outd/${exec_name}_${version}_$os-$arch$suffix"
+    target="${exec_name}_${version}_$os-$arch$suffix"
 
-    cp tkey-random-generator $target
-    sha512sum "$target" >"$target.sha512"
+    cp tkey-random-generator "$outd/$target"
+    (cd "$outd" && sha512sum "$target" >"$target.sha512")
 
 done
 
@@ -58,11 +58,11 @@ done
 # binary
 make -s -C gotools lipo
 
-universaltarget="$outd/${exec_name}_${version}_darwin-universal"
-./gotools/lipo -output "$universaltarget" -create \
+universaltarget="${exec_name}_${version}_darwin-universal"
+./gotools/lipo -output "$outd/$universaltarget" -create \
                "$outd/${exec_name}_${version}_darwin-amd64" \
                "$outd/${exec_name}_${version}_darwin-arm64"
-sha512sum "$universaltarget" >"$universaltarget.sha512"
+(cd "$outd" && sha512sum "$universaltarget" >"$universaltarget.sha512")
 
 set -x
 ls -l "$outd"

--- a/make-release-build.sh
+++ b/make-release-build.sh
@@ -56,9 +56,10 @@ do
         else
             suffix=""
         fi
-        target="$outd/${exec_name}_${version}_$os-$arch$suffix"
-        cp tkey-random-generator $target
-        sha512sum "$target" >"$target.sha512"
+        target="${exec_name}_${version}_$os-$arch$suffix"
+
+        cp tkey-random-generator "$outd/$target"
+        (cd "$outd" && sha512sum "$target" >"$target.sha512")
     done
 done
 


### PR DESCRIPTION
## Description

The `.sha512`-files generated by `make-release-build.sh` and `make-release-build-macos.sh` contain `release-builds/` in the path to the binary. Like this: `<DIGEST>   release-builds/tkey-random-generator_0.0.3_linux-amd64`.

This PR removes `release-builds/` so the user can run `sha512sum -c *.sha512` without having to recreate the `release-builds` directory.

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
