### PR TITLE
Handle TKey Unlocked like Bellatrix

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## v0.0.4
+
+- Update tkeyclient to v1.3.1 to handle TKey Unlocked (product ID 8)
+  as a Bellatrix when it comes to USS digest handling.
+
+- Only allow `--force-full-uss` when either `--uss` or `--uss-file` is
+  used.
+
+Full
+[changelog](https://github.com/tillitis/tkey-random-generator/compare/v0.0.3...v0.0.4).
+
 ## v0.0.3
 
 - Update tkeyclient version because of a vulnerability leaving some

--- a/cmd/tkey-random-generator/main.go
+++ b/cmd/tkey-random-generator/main.go
@@ -174,6 +174,12 @@ Flags:`, os.Args[0])
 			os.Exit(2)
 		}
 
+		if forceFullUSS && fileUSS == "" != enterUSS {
+			le.Printf("--force-full-uss unusable unless you also specify --uss or --uss-file.\n\n")
+			cmdGen.Usage()
+			os.Exit(2)
+		}
+
 		if cmdGen.NArg() < 1 {
 			le.Printf("Bytes to generate required.\n\n")
 			cmdGen.Usage()

--- a/doc/tkey-random-generator.1
+++ b/doc/tkey-random-generator.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "tkey-random-generator" "1" "2026-03-16"
+.TH "tkey-random-generator" "1" "2026-03-23"
 .PP
 .SH NAME
 .PP
@@ -60,6 +60,8 @@ Output random data as binary to FILE.\&
 .RS 4
 Force the use of a full 32 byte USS digest.\& For backwards compatibility
 the default is 31 bytes.\&
+.PP
+Only usable with \fB--uss\fR or \fB--uss-file\fR.\&
 .PP
 .RE
 \fB-p\fR, \fB--port PATH\fR

--- a/doc/tkey-random-generator.scd
+++ b/doc/tkey-random-generator.scd
@@ -47,6 +47,8 @@ Output can be chosen between stdout (in hexadecimal) or a binary file.
 	Force the use of a full 32 byte USS digest. For backwards compatibility
 	the default is 31 bytes.
 
+	Only usable with *--uss* or *--uss-file*.
+
 *-p*, *--port PATH*
 
 	Set serial port device PATH. If this is not passed, auto-detection

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.1
 require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/spf13/pflag v1.0.5
-	github.com/tillitis/tkeyclient v1.3.0
+	github.com/tillitis/tkeyclient v1.3.1
 	github.com/tillitis/tkeyutil v0.0.9
 	golang.org/x/crypto v0.40.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG0
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
 github.com/tillitis/tkeyclient v1.3.0 h1:fUlghD+xvtL+qoajgrsetCC7KPwSfpjDDgqxMOBA2VU=
 github.com/tillitis/tkeyclient v1.3.0/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
+github.com/tillitis/tkeyclient v1.3.1 h1:IouMAtwwXewhXLmcySBmXuyFuI4WoAw8NQj+gFWlLaw=
+github.com/tillitis/tkeyclient v1.3.1/go.mod h1:7VtzyEjm08Wf+1zdrs20HsvM+WzhyztinvGG2/HY+Is=
 github.com/tillitis/tkeyutil v0.0.9 h1:WWF4Emxch32TczYjjYwl45GMtxsD9l8432mZaX6u8mw=
 github.com/tillitis/tkeyutil v0.0.9/go.mod h1:+vxU9HmwR2pdPRYg1YlmWW46h2XADdSAhCGUQCryzJg=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=


### PR DESCRIPTION
## Description

- Update tkeyclient to v1.3.1 to get Bellatrix behaviour on TKey Unlocked.
- Only allow --force-full-uss with --uss or --uss-file

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
